### PR TITLE
fix: Set github token in release please action properly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v3
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           release-type: ruby
           package-name: DriftHound
           version-file: lib/drifthound/version.rb
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Set `token` according to actions documentation