### PR TITLE
fix: Configure production mode for basic app

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -9,9 +9,4 @@ test:
   adapter: test
 
 production:
-  adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
-  polling_interval: 0.1.seconds
-  message_retention: 1.day
+  adapter: async

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # Disable image variant processing since we don't use image uploads
+  config.active_storage.variant_processor = :disabled
+
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true
 


### PR DESCRIPTION
Some basic configuration tweaks to get ready for production mode.

- Disable `active_storage.variant_processor`
- Set cable `adapter: async` 