### PR TITLE
feat: Improve UX looks and long names handling

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,6 +1,7 @@
 .checks-header {
   display: grid;
-  grid-template-columns: 40px 1fr 2fr 1fr 1fr 100px;
+  grid-template-columns: 40px 90px minmax(100px, 1fr) auto auto auto;
+  column-gap: 2.5rem;
   padding: 0.75rem 1.5rem;
   background-color: #e5e7eb;
   font-size: 0.75rem;
@@ -8,19 +9,19 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
+  align-items: center;
 }
 .check-summary {
   display: grid;
-  grid-template-columns: 40px 1fr 2fr 1fr 1fr 100px;
+  grid-template-columns: 40px 90px minmax(100px, 1fr) auto auto auto;
+  column-gap: 2.5rem;
   padding: 1rem 1.5rem;
   align-items: center;
   cursor: pointer;
   transition: background-color 0.15s;
-  gap: 0.5em;
 }
 .col-check-number {
-  min-width: 40px;
-  max-width: 40px;
+  text-align: center;
   justify-content: center;
 }
 .check-number-badge {
@@ -88,9 +89,20 @@
   cursor: pointer;
 }
 /* ===== Project/Environment Dashboard Table ===== */
+.projects-table {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(120px, 1fr) auto auto;
+  column-gap: 2rem;
+  background: var(--color-card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
 .project-envs-header {
   display: grid;
-  grid-template-columns: 2fr 2fr 1fr 1.5fr;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
   padding: 0.75rem 1.5rem;
   background-color: #e5e7eb;
   font-size: 0.75rem;
@@ -102,7 +114,8 @@
 
 .project-env-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1fr 1.5fr;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
   align-items: center;
   padding: 1rem 1.5rem;
   border-bottom: 1px solid var(--color-border);
@@ -116,8 +129,26 @@
 }
 
 .project-env-row:hover {
-  background-color: #e5e7eb;
+  background-color: #f9fafb;
   text-decoration: none;
+}
+
+/* Handle long text in dashboard table */
+.col-project,
+.col-environment {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.col-status {
+  white-space: nowrap;
+}
+
+.col-time {
+  white-space: nowrap;
+  text-align: right;
 }
 /*
  * This is a manifest file that'll be compiled into application.css.
@@ -262,12 +293,12 @@ h1, h2, h3 {
   margin-bottom: 1rem;
 }
 
-.projects-table {
-  background: var(--color-card);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-md);
-  overflow: hidden;
+.projects-list {
+  overflow-x: auto;
+  padding: 0.25rem;
+  margin: -0.25rem;
 }
+
 
 .project-row {
   display: grid;
@@ -353,6 +384,7 @@ h1, h2, h3 {
   width: 12px;
   height: 12px;
   border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .status-indicator--large {
@@ -450,22 +482,60 @@ h1, h2, h3 {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 2rem;
+  gap: 1rem;
+  overflow: hidden;
 }
 
 .breadcrumb {
-  font-size: 1.25rem;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+  flex: 1;
+  max-width: 70%;
 }
 
 .breadcrumb a {
   color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 250px;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.breadcrumb a:first-child {
+  flex-shrink: 0;
+  max-width: none;
 }
 
 .breadcrumb span {
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 250px;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.breadcrumb-sep {
+  flex-shrink: 0;
+  font-weight: normal;
+  max-width: none;
+  overflow: visible;
 }
 
 .back-link {
   font-size: 0.875rem;
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: min(350px, calc(100vw - 6rem));
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .project-summary-card {
@@ -480,11 +550,14 @@ h1, h2, h3 {
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.5rem;
+  gap: 1rem;
+  overflow: hidden;
 }
 
 .project-summary-card .summary-bottom {
   position: relative;
   padding: 1rem 1.5rem;
+  overflow: hidden;
 }
 
 .project-summary-card .summary-bottom::before {
@@ -502,11 +575,18 @@ h1, h2, h3 {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  overflow: hidden;
+  min-width: 0;
+  flex: 1;
 }
 
 .project-summary-card .main-info h1 {
   margin: 0;
   font-size: 1.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
 }
 
 .project-emoji {
@@ -522,11 +602,18 @@ h1, h2, h3 {
 .environment-title {
   font-size: 1.25rem;
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex-shrink: 1;
+  max-width: 250px;
 }
 
 .env-separator {
   color: #bbb;
   font-size: 1.2rem;
+  flex-shrink: 0;
 }
 
 .directory-icon {
@@ -548,6 +635,8 @@ h1, h2, h3 {
   gap: 0.75rem;
   font-size: 0.9rem;
   color: var(--color-text-muted);
+  max-width: 100%;
+  min-width: 0;
 }
 
 .project-detail-item a {
@@ -557,6 +646,10 @@ h1, h2, h3 {
   padding: 0.3rem 0.6rem;
   border-radius: 4px;
   text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: min(600px, calc(100vw - 6rem));
 }
 
 .project-detail-item a:hover {
@@ -572,6 +665,7 @@ h1, h2, h3 {
   background-repeat: no-repeat;
   background-position: center;
   opacity: 0.7;
+  flex-shrink: 0;
 }
 
 .repo-icon--github {
@@ -609,6 +703,8 @@ h1, h2, h3 {
   padding: 3px 8px;
   border-radius: 10px;
   line-height: 1;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .status-pill--ok {
@@ -667,9 +763,17 @@ h1, h2, h3 {
 .last-check-time {
   font-size: 0.875rem;
   color: var(--color-text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 /* ===== Check History ===== */
+.check-history {
+  overflow-x: auto;
+  padding: 0.25rem;
+  margin: -0.25rem;
+}
+
 .check-history h2 {
   font-size: 1.25rem;
   margin-bottom: 1rem;
@@ -701,7 +805,8 @@ h1, h2, h3 {
 
 .check-summary {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 100px;
+  grid-template-columns: 40px 90px minmax(100px, 1fr) auto auto auto;
+  column-gap: 2.5rem;
   padding: 1rem 1.5rem;
   align-items: center;
   cursor: pointer;
@@ -728,6 +833,11 @@ h1, h2, h3 {
 .col-summary, .col-duration, .col-time {
   font-size: 0.875rem;
   color: var(--color-text-muted);
+  min-width: 0;
+}
+
+.environment-row .col-time {
+  text-align: right;
 }
 
 .oneline {
@@ -789,6 +899,12 @@ h1, h2, h3 {
 }
 
 /* ===== Environments List ===== */
+.environments-list {
+  overflow-x: auto;
+  padding: 0.25rem;
+  margin: -0.25rem;
+}
+
 .environments-list h2 {
   font-size: 1.25rem;
   margin-bottom: 1rem;
@@ -805,8 +921,9 @@ h1, h2, h3 {
 
 .environments-header {
   display: grid;
-  grid-template-columns: 1fr 1.5fr 2.5fr 1fr 1fr 40px;
-  /* Status | Environment | Summary (wider) | (spacer) | Last Check | Arrow */
+  grid-template-columns: 100px minmax(150px, 300px) 1fr 120px 40px;
+  /* Status | Environment | Summary | Last Check | Arrow */
+  column-gap: 1.5rem;
   padding: 0.75rem 1.5rem;
   background-color: #e5e7eb;
   font-size: 0.75rem;
@@ -818,8 +935,9 @@ h1, h2, h3 {
 
 .environment-row {
   display: grid;
-  grid-template-columns: 1fr 1.5fr 2.5fr 1fr 1fr 40px;
-  /* Status | Environment | Summary (wider) | (spacer) | Last Check | Arrow */
+  grid-template-columns: 100px minmax(150px, 300px) 1fr 120px 40px;
+  /* Status | Environment | Summary | Last Check | Arrow */
+  column-gap: 1.5rem;
   padding: 1rem 1.5rem;
   align-items: center;
   border-bottom: 1px solid var(--color-border);
@@ -833,17 +951,22 @@ h1, h2, h3 {
 }
 
 .environment-row:hover {
-  background-color: var(--color-bg);
+  background-color: #f9fafb;
   text-decoration: none;
 }
 
 .col-name {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .environment-name {
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .environment-key {

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -42,104 +42,93 @@
       <span class="filter-search">
         <span class="filter-icon">🔍</span>
         <input id="name-filter" type="text" placeholder="Search projects or environments…" class="filter-input" data-dashboard-filter-target="nameFilter">
+        <button id="clear-filters" class="filter-clear" title="Clear filters" style="display:none;" data-dashboard-filter-target="clearBtn">✕</button>
       </span>
-      <button id="clear-filters" class="filter-clear" title="Clear filters" style="display:none;" data-dashboard-filter-target="clearBtn">✕</button>
     </div>
     <style>
     .dashboard-filter-bar {
       display: flex;
       align-items: center;
       gap: 1rem;
-      background: #f3f4f6;
-      border-radius: 2em;
-      padding: 0.5em 1.5em;
+      background: var(--color-card);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow-md);
+      padding: 1rem 1.5rem;
       margin-bottom: 1.5em;
-      box-shadow: 0 2px 8px 0 #0001;
-      flex-wrap: wrap;
-      position: relative;
-      padding-right: 3.2em;
     }
     .filter-pill {
-      border: none;
-      background: #fff;
-      border-radius: 2em;
-      padding: 0.4em 2.2em 0.4em 1.2em;
+      border: 1px solid #e5e7eb;
+      background: #f9fafb;
+      border-radius: 6px;
+      padding: 0 2.5em 0 0.75em;
       font-size: 1em;
-      box-shadow: 0 1px 4px 0 #0001;
+      height: 2.5em;
+      line-height: 2.5em;
       outline: none;
-      transition: box-shadow 0.15s;
+      transition: border-color 0.15s;
       appearance: none;
       -webkit-appearance: none;
       -moz-appearance: none;
-      position: relative;
+      background-image: url('data:image/svg+xml;utf8,<svg fill="%236b7280" height="16" viewBox="0 0 20 20" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.06l3.71-3.83a.75.75 0 1 1 1.08 1.04l-4.25 4.39a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06z"/></svg>');
+      background-repeat: no-repeat;
+      background-position: right 0.75em center;
+      background-size: 1em;
+      overflow: visible;
     }
     .filter-pill::-ms-expand {
       display: none;
     }
-    .filter-pill {
-      background-image: url('data:image/svg+xml;utf8,<svg fill="%236b7280" height="16" viewBox="0 0 20 20" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.06l3.71-3.83a.75.75 0 1 1 1.08 1.04l-4.25 4.39a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06z"/></svg>');
-      background-repeat: no-repeat;
-      background-position: right 1.1em center;
-      background-size: 1em;
-    }
-    .filter-pill:focus, .filter-pill[style*="background"] {
-      box-shadow: 0 0 0 2px #2563eb55;
-      background: #e0e7ff;
+    .filter-pill:focus {
+      border-color: #2563eb;
     }
     .filter-sep {
       width: 1px;
-      height: 2em;
+      height: 1.5em;
       background: #e5e7eb;
-      margin: 0 0.5em;
     }
     .filter-search {
       display: flex;
       align-items: center;
-      background: #fff;
-      border-radius: 2em;
-      padding: 0.2em 1em;
-      box-shadow: 0 1px 4px 0 #0001;
-      flex: 1 1 350px;
-      min-width: 300px;
-      max-width: 600px;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      padding: 0 0.75em;
+      height: 2.5em;
+      flex: 1;
+      min-width: 0;
     }
     .filter-icon {
-      font-size: 1.1em;
+      font-size: 1em;
       margin-right: 0.5em;
-      color: #888;
+      color: #9ca3af;
+      flex-shrink: 0;
     }
     .filter-input {
       border: none;
       background: transparent;
       outline: none;
       font-size: 1em;
-      min-width: 250px;
+      min-width: 0;
       width: 100%;
-      padding: 0.3em 0;
+    }
+    .filter-input::placeholder {
+      color: #9ca3af;
     }
     .filter-clear {
-      position: absolute;
-      top: 50%;
-      right: 2em;
-      transform: translateY(-50%);
       border: none;
-      background: #fff;
-      color: #888;
-      border-radius: 2em;
-      height: 2.4em;
-      font-size: 1em;
+      background: transparent;
+      color: #9ca3af;
+      font-size: 1.2em;
       display: flex;
       align-items: center;
       justify-content: center;
-      box-shadow: 0 1px 4px 0 #0001;
       cursor: pointer;
-      transition: background 0.15s, color 0.15s;
-      padding: 0 1.2em;
-      z-index: 1;
+      transition: color 0.15s;
+      padding: 0 0.25em;
+      margin-left: 0.5em;
     }
     .filter-clear:hover {
-      background: #f59e0b;
-      color: #fff;
+      color: #f59e0b;
     }
     </style>
     <% if @project_environments.empty? %>
@@ -157,8 +146,8 @@
         </div>
         <% @project_environments.each do |project, env| %>
           <%= link_to project_environment_path(project.key, env.key), class: "project-env-row project-row--#{env.status}", data: { environment: env.name, status: env.last_check_status, dashboard_filter_target: "projectRow" } do %>
-            <span class="col-project"><%= project.name %></span>
-            <span class="col-environment"><%= env.name %></span>
+            <span class="col-project" title="<%= project.name %>"><%= project.name %></span>
+            <span class="col-environment" title="<%= env.name %>"><%= env.name %></span>
             <span class="col-status">
               <span class="status-indicator status-indicator--<%= env.last_check_status %>"></span>
               <span class="status-text status-text--<%= env.last_check_status %>"><%= env.last_check_status.upcase %></span>

--- a/app/views/environments/show.html.erb
+++ b/app/views/environments/show.html.erb
@@ -1,9 +1,9 @@
 <div class="environment-detail">
   <header class="project-header">
-    <div class="breadcrumb">
-      <%= link_to "DriftHound", root_path %> › <%= link_to @project.name, project_path(@project.key) %> › <span><%= @environment.name %></span>
+    <div class="breadcrumb" title="<%= @project.name %> › <%= @environment.name %>">
+      <%= link_to "DriftHound", root_path %><span class="breadcrumb-sep"> › </span><%= link_to @project.name, project_path(@project.key), title: @project.name %><span class="breadcrumb-sep"> › </span><span title="<%= @environment.name %>"><%= @environment.name %></span>
     </div>
-    <%= link_to "← Back to #{@project.name}", project_path(@project.key), class: "back-link" %>
+    <%= link_to "← Back to #{@project.name}", project_path(@project.key), class: "back-link", title: "Back to #{@project.name}" %>
   </header>
 
   <section class="project-summary-card">
@@ -11,9 +11,9 @@
       <div class="main-info">
         <% last_status = @environment.last_check_status %>
         <span class="status-indicator status-indicator--<%= last_status %>"></span>
-        <h1><%= @project.name %></h1>
+        <h1 title="<%= @project.name %>"><%= @project.name %></h1>
         <span class="env-separator">&bull;</span>
-        <span class="environment-title"><%= @environment.name %></span>
+        <span class="environment-title" title="<%= @environment.name %>"><%= @environment.name %></span>
         <span class="env-separator">&bull;</span>
         <span class="status-pill status-pill--<%= last_status %>"><%= last_status.upcase %></span>
       </div>
@@ -75,19 +75,19 @@
     <% else %>
       <div class="checks-table">
         <div class="checks-header">
-          <span style="text-align:center; padding-right:0.75em;">#</span>
-          <span style="padding-left:0.25em;">Status</span>
+          <span style="text-align: center;">#</span>
+          <span>Status</span>
           <span>Summary</span>
           <span>Duration</span>
           <span>Execution Time</span>
-          <span style="text-align:right;">Details</span>
+          <span style="text-align: right;">Details</span>
         </div>
         <% total_checks = @drift_checks.size %>
         <% @drift_checks.each_with_index do |check, idx| %>
           <div class="check-row" data-controller="expandable">
-            <div class="check-summary" style="display: grid; grid-template-columns: 40px 1fr 2fr 1fr 1fr 100px; align-items: center; gap: 0.5em;" data-action="click->expandable#toggle">
-                <span class="col-check-number" style="text-align:center; font-weight:600; color:#888;">
-                  <span class="check-number-badge"><%= check.execution_number %></span>
+            <div class="check-summary" data-action="click->expandable#toggle">
+              <span class="col-check-number">
+                <span class="check-number-badge"><%= check.execution_number %></span>
               </span>
               <span class="col-status">
                 <span class="status-indicator status-indicator--<%= check.status %>"></span>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,7 +1,7 @@
 <div class="project-detail">
   <header class="project-header">
-    <div class="breadcrumb">
-      <%= link_to "DriftHound", root_path %> › <span><%= @project.name %></span>
+    <div class="breadcrumb" title="<%= @project.name %>">
+      <%= link_to "DriftHound", root_path %><span class="breadcrumb-sep"> › </span><span title="<%= @project.name %>"><%= @project.name %></span>
     </div>
     <%= link_to "← Back to Dashboard", root_path, class: "back-link" %>
   </header>
@@ -10,7 +10,7 @@
     <div class="summary-top">
       <div class="main-info">
         <span class="project-emoji">📦</span>
-        <h1><%= @project.name %></h1>
+        <h1 title="<%= @project.name %>"><%= @project.name %></h1>
       </div>
       <div>
         <% if @project.last_checked_at %>
@@ -52,11 +52,10 @@
           <span>Status</span>
           <span>Environment</span>
           <span>Summary</span>
-          <span></span>
-          <span>Last Check</span>
+          <span style="text-align: right;">Last Check</span>
           <span></span>
         </div>
-        
+
         <% @environments.each do |environment| %>
           <%= link_to project_environment_path(@project.key, environment.key), class: "environment-row" do %>
             <span class="col-status">
@@ -64,7 +63,7 @@
               <span class="status-text status-text--<%= environment.status %>"><%= environment.status.upcase %></span>
             </span>
             <span class="col-name">
-              <span class="environment-name"><%= environment.name %></span>
+              <span class="environment-name" title="<%= environment.name %>"><%= environment.name %></span>
             </span>
             <span class="col-summary oneline">
               <% last_check = environment.drift_checks.order(created_at: :desc).first %>
@@ -84,7 +83,6 @@
                 —
               <% end %>
             </span>
-            <span></span>
             <span class="col-time">
               <% if environment.last_checked_at %>
                 <%= time_ago_in_words(environment.last_checked_at) %> ago

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -260,6 +260,38 @@ env6.update!(status: :drift)
 puts "  ✓ Status changed 'ok' → 'drift' but no channels configured"
 puts ""
 
+# Scenario 7: Long project and environment names (for testing UI overflow)
+project7 = Project.create!(
+  name: "super-long-project-name-for-enterprise-infrastructure-management-system",
+  key: "super-long-project-name-for-enterprise-infrastructure-management-system",
+  repository: "https://github.com/acme-corporation/super-long-project-name-for-enterprise-infrastructure-management-system"
+)
+
+env7 = project7.environments.create!(
+  name: "production-us-east-1-primary-datacenter-cluster-a",
+  key: "production-us-east-1-primary-datacenter-cluster-a",
+  status: :ok,
+  last_checked_at: 5.minutes.ago,
+  directory: "terraform/environments/production/us-east-1/primary-datacenter/cluster-a"
+)
+
+env7.drift_checks.create!(
+  status: :ok,
+  add_count: 0,
+  change_count: 0,
+  destroy_count: 0,
+  duration: 120,
+  raw_output: "No changes. Infrastructure matches code.",
+  created_at: Time.current,
+  execution_number: 1
+)
+
+puts "Scenario 7: Long Names (UI overflow testing)"
+puts "  Project: #{project7.name}"
+puts "  Environment: #{env7.name}"
+puts "  ✓ Created for testing long name overflow in UI"
+puts ""
+
 puts "=" * 80
 puts "Summary"
 puts "=" * 80


### PR DESCRIPTION
Improve how long names for projects and environments are handled.

Also improve overall looking and cosmetics.

Main view:
<img width="1094" height="601" alt="Captura de pantalla 2025-12-13 a las 13 52 26" src="https://github.com/user-attachments/assets/e62ccbc5-a5a3-4c3b-be14-e99cbd10acd7" />

Project view:
<img width="1133" height="415" alt="Captura de pantalla 2025-12-13 a las 13 50 52" src="https://github.com/user-attachments/assets/30657450-a6a8-4960-a688-1d4029b2993e" />


Environment view:
<img width="1131" height="491" alt="Captura de pantalla 2025-12-13 a las 13 50 44" src="https://github.com/user-attachments/assets/a5e85f5a-ebad-4a1b-bd18-1cb49cca981b" />

