### PR TITLE
fix: point release workflow to manifest config files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
-          release-type: ruby
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Replace `release-type: ruby` in the workflow with `config-file` and `manifest-file` parameters so the action reads `release-please-config.json` (which sets `release-type: generic` and `version-file`) instead of ignoring it

## Test plan
- [ ] Merge to main and confirm release-please action opens a PR that bumps `lib/drifthound/version.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)