### PR TITLE
fix: use simple release type in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "generic",
+      "release-type": "simple",
       "version-file": "lib/drifthound/version.rb"
     }
   }


### PR DESCRIPTION
## Summary
- Change `release-type` from `generic` to `simple` in `release-please-config.json`
- `generic` is only valid as an `extra-files` updater type, not as a top-level release type — it caused the action to fail with "Unknown release type: generic"
- `simple` supports the `# x-release-please-version` marker in `lib/drifthound/version.rb` and manages CHANGELOG versioning

## Test plan
- [ ] Merge to main and confirm release-please action runs without errors and opens a PR that bumps `lib/drifthound/version.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)