### PR TITLE
fix: use extra-files generic updater for version.rb

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,12 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "version-file": "lib/drifthound/version.rb"
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "lib/drifthound/version.rb"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove `version-file` from config — with `simple` release type it replaces the entire file with just the version string
- Use `extra-files` with `type: generic` instead, which finds the line with `# x-release-please-version` marker and updates only the version string in place

## Test plan
- [ ] Merge and confirm release-please PR updates only the version string in `lib/drifthound/version.rb`, leaving the rest of the file intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)